### PR TITLE
Moving discussion-like comments out of results

### DIFF
--- a/manuscript/main.tex
+++ b/manuscript/main.tex
@@ -234,7 +234,7 @@ Weschler Preschool and Primary Scale of Intelligence, 4th Edition (WPPSI-4)
 \cite{wechslerWechslerPreschoolPrimary2012}
 and Weschler Intelligence Scale for Children, 5th Edition (WISC-V)
 \cite{wechslerWechslerIntelligenceScale1949}.
-Finally, we also assessed emerging brain structure magnetic resonance imaging
+Finally, we also assessed emerging brain structure using magnetic resonance imaging
 (MRI). Through a combination of classical statistical analysis and machine
 learning, we find that the development of the gut microbiome,
 children's cognitive abilities, and brain structure are intimately linked, with
@@ -247,7 +247,7 @@ performance and brain structure.
 
 We investigated the co-development of the brain and the microbiome in
 361 healthy and neurotypically-developing children (163 female) between 82 days and 10 years of age
-(Table 1,  Figure 1A, Supplementary Figure 1)\cite{forrestAdvancingScienceChildren2018}
+(Table 1,  Figure 1A, Supplementary Figure 1)
 using a variety of orthogonal microbial and neurocognitive measures.
 These included shotgun metagenomic sequencing,
 age-appropriate cognitive and behavioral assessments
@@ -260,9 +260,9 @@ and the WISC-V for children older than 6), but were normalized to a common scale
 As expected, the greatest differences in microbial taxa were observed across
 child age (Figure 1C-D, PCoA axis 1), while older children were primarily
 stratified into Bacteroidetes-dominant, Firmicutes-dominant, or
-high-\emph{Prevotella copri} (Supplementary Figure 2). Overall variation
-in gut microbial genes and also in brain volume profiles was similarly
-driven largely by subject age (Figure 1E-F).
+high-abundance \emph{Prevotella copri} (Supplementary Figure 2).
+Overall subject-to-subject variation in gut microbial genes
+and brain volume profiles was similarly driven largely by subject age (Figure 1E-F).
 
 \begin{sidewaysfigure}[!htb]
     \centering
@@ -318,16 +318,19 @@ driven largely by subject age (Figure 1E-F).
         & College grad & 90 (24.9\%) & 17 (23.0\%) & 69 (26.8\%) \\ \cline{2-5}
         & Grad/professional school & 123 (34.1\%) & 15 (20.3\%) & 104 (40.5\%) \\\hline\hline
     \end{tabular}
-    \caption{\label{tab:demo}Subject demographics}
+    \caption{\label{tab:demo}Subject demographics of the ECHO RESONANCE cohort.}
 \end{table}
 
 As several prior studies have demonstrated links between specific gut taxa
 with ASD \cite{liuAlteredGutMicrobiota2019,wanUnderdevelopmentGutMicrobiota2021},
-adult cognitive skill (e.g., executive functioning)\cite{magnussonRelationshipsDietrelatedChanges2015},
-and adult mental health (both anxiety and depressive symptioms)\cite{mayneris-perxachsMicrobiotaAlterationsProline2022,needhamGutderivedMetaboliteAlters2022}
-we sought to determine if specific taxa or gene functions were linked with normal cognitive development in children.
+adult cognitive skill (e.g., executive functioning)
+\cite{magnussonRelationshipsDietrelatedChanges2015},
+and adult mental health (both anxiety and depressive symptioms)
+\cite{mayneris-perxachsMicrobiotaAlterationsProline2022,needhamGutderivedMetaboliteAlters2022},
+we sought to determine if specific taxa or gene functions were linked
+with normal cognitive development in children.
 To test if variations in gut microbial taxa,
-their genes, or their metabolism are associated with neurocognitive
+their genes, or their metabolism were associated with neurocognitive
 development, we used permutation analysis of variance (PERMANOVA) 
 that included the $\beta$ diversity of microbial taxa and gene functions,
 neuroimaging-derived volume measures of cortical and subcortical structures,
@@ -344,7 +347,7 @@ was associated with a small but significant variation in cognitive function scor
 as was variation in microbial gene functions (R\textsuperscript{2} = 0.0119, q \textless{} 0.001).
 Variation in microbial taxa and genes was not significantly associated with cognitive
 function in children under 6 months, though this may be due to the low
-taxonomic diversity and broad lack of overlap between taxa in infants.
+taxonomic diversity and broad lack of overlap between taxa in infants (Figure 1G).
 As expected, age was significantly associated with microbial beta
 diversity (taxa R\textsuperscript{2} = 0.0215, and  gene functions
 annotated with UniRef90s - clusters of 90\% similarity
@@ -421,11 +424,11 @@ test this, we performed feature set enrichment analysis (FSEA) on groups
 of genes with neuroactive potential
 \cite{valles-colomerNeuroactivePotentialHuman2019}
 and concurrent cognitive ability score (Table 2, Figure 2C-G) and found that
-several metabolic pathways were significantly enriched or depleted in
+several metabolic pathways were either significantly enriched or depleted in
 children with higher cognitive ability scores. This was true both when
-considering all ages together, though the enrichment of most
+considering all ages (0-120 months) together, though the enrichment of most
 pathways was more pronounced either in children under 6 months or those over 18
-months. For example, genes for degrading the 3-carbon SCFA propionate
+months. For example, genes for degrading the 3-carbon SCFA, propionate,
 were significantly depleted in children with higher cognitive ability
 scores across all age groups tested (Table 2; propionate degradation I,
 under 6 months, enrichment score (E.S.) = -0.542, corrected p-value (q)
@@ -475,8 +478,9 @@ FSEA relies on understanding functional relationships between individual
 genes. However, because the relationships between individual taxa are
 still largely unknown, we turned to Random Forest (RF) models, a family of 
 unsupervised non-parametric machine learning (ML) method that enables
-the identification of underlying patterns in large numbers of individual
-features (here, microbial species). Previous studies have reported
+the identification of underlying patterns in large numbers of individual features
+(here, microbial species).
+Previous studies have reported
 successful use of RFs for processing highly-dimensional and sparse data
 from the domain of genomics
 \cite{amaratungaEnrichedRandomForests2008,brieucPracticalIntroductionRandom2018,chenRandomForestsGenomic2012,franzosaGutMicrobiomeStructure2019,stephanRandomForestApproach2015},

--- a/manuscript/main.tex
+++ b/manuscript/main.tex
@@ -693,6 +693,81 @@ importances, Left = 2.6\%, Right = 1.8\%).
 
 \section*{Discussion}
 
+\subsection*{Deleted}
+
+SCFAs are produced by anaerobic fermentation of dietary fiber
+and have been linked with immune system regulation as well as directly
+with brain function \cite{dalileRoleShortchainFatty2019}
+
+Menaquinone has several isoforms, one of
+which, MK-4, has been found to be decreased in children diagnosed with ASD
+\cite{dongCorrelationSerumConcentrations2021}
+and is potentially neuroprotective in both rodents and humans
+\cite{elkattawyVitaminK2Menaquinone72022}.
+
+Glutamate is a
+critical neurotransmitter controlling neuronal excitatory/inhibitory
+signaling along with gamma-aminobutyric acid (GABA), and their balance
+in the brain controls neural plasticity and learning, particularly in
+the developing brain
+\cite{cohenkadoshLinkingGABAGlutamate2015,palomo-buitragoGlutamateInteractionsObesity2019}.
+
+Tryptophan metabolism, including
+microbial metabolism of tryptophan, has previously been linked with
+autism in children
+\cite{hoshinoBloodSerotoninFree1984,xiaoFecalMicrobiomeTransplantation2021}.
+
+For children under 6 months, only \emph{B. wexlerae} was
+significantly associated with cognitive function in linear models, but
+was ranked 20th in importance for RF models.
+
+The importance metric
+employed (MDI) is a measure of how well the variable differentiates
+(splits) sets of samples by creating subgroups that reduce the
+intra-group deviations, while also accounting for the amount of samples
+affected by a split.
+
+Most healthy individuals have a
+rightward asymmetry in the nucleus accumbens,
+which is involved in reward learning and risk taking behaviours
+\cite{ernstAmygdalaNucleusAccumbens2005,yauNucleusAccumbensResponse2012}.
+Reduced asymmetry between right and left nucleus accumbens
+has been associated with substance use disorder in young adults
+\cite{caoMappingCorticalSubcortical2021}. The accumbens area is also
+associated with reward control, and in individuals diagnosed with ADHD,
+it has been shown to have a divergent neuromorphology
+\cite{hoogmanSubcorticalBrainVolume2017}.
+
+[\emph{Anaerostipes hadrus}] is a butyrate-producing anaerobe that has been positively
+associated with cognitive function
+\cite{kantGenomeSequenceButyrateProducing2015,liCorrelationsGutMicrobiota2022}.
+Its importance is, however, heavily loaded on the volume
+of entire major lobes (frontal, parietal), which cannot be readily
+correlated to specific cognitive functions
+
+Reduction in the nucleus accumbens has been associated with
+depression symptoms \cite{wackerRoleNucleusAccumbens2009},
+and increased levels of the \emph{Alistipes} genus have been
+observed in patients with depressive disorder
+\cite{jiangAlteredFecalMicrobiota2015}.
+
+[The right anterior cingulate] has been linked to social cognition and reward-based
+decision making
+\cite{appsAnteriorCingulateGyrus2016,boesRightAnteriorCingulate2008,bushDorsalAnteriorCingulate2002}.
+Equol has a strong estrogenic effect
+\cite{setchellSEquolPotentLigand2005},
+and in the anterior cingulate, estrogen has been shown to regulate
+pain-related aversion
+\cite{xiaoEstrogenAnteriorCingulate2013}.
+
+\textit{R. gnavus} is increased in individuals with insulin
+resistance and obesity \cite{leyHumanGutMicrobes2006},
+conditions that are known to produce structural abnormalities in the brain
+\cite{opelBrainStructuralAbnormalities2021}.
+
+
+\subsection*{Main}
+
 The relationship between the gut microbiome and brain function via the
 gut-microbiome-brain axis has gained increasing acceptance largely as a
 result of human epidemiological studies investigating atypical

--- a/manuscript/main.tex
+++ b/manuscript/main.tex
@@ -672,7 +672,7 @@ basal forebrain, especially the cingulate and the accumbens. This
 cluster contains \emph{B. ovatus} and \emph{B. uniformis},
 but also \emph{Alistipes finegoldii and Streptococcus salivaris}.
 
-Both \emph{A. equolofaciens} and \emph{A. celatus,} two closely-related
+Both \emph{A. equolofaciens} and \emph{A. celatus}, two closely-related
 equol-producing species, are examples of the second contribution
 pattern, where a model is dominated by a small number of taxa.
 Each of these species were highly important in predicting the relative volume of
@@ -727,17 +727,6 @@ employed (MDI) is a measure of how well the variable differentiates
 intra-group deviations, while also accounting for the amount of samples
 affected by a split.
 
-Most healthy individuals have a
-rightward asymmetry in the nucleus accumbens,
-which is involved in reward learning and risk taking behaviours
-\cite{ernstAmygdalaNucleusAccumbens2005,yauNucleusAccumbensResponse2012}.
-Reduced asymmetry between right and left nucleus accumbens
-has been associated with substance use disorder in young adults
-\cite{caoMappingCorticalSubcortical2021}. The accumbens area is also
-associated with reward control, and in individuals diagnosed with ADHD,
-it has been shown to have a divergent neuromorphology
-\cite{hoogmanSubcorticalBrainVolume2017}.
-
 [\emph{Anaerostipes hadrus}] is a butyrate-producing anaerobe that has been positively
 associated with cognitive function
 \cite{kantGenomeSequenceButyrateProducing2015,liCorrelationsGutMicrobiota2022}.
@@ -751,19 +740,11 @@ and increased levels of the \emph{Alistipes} genus have been
 observed in patients with depressive disorder
 \cite{jiangAlteredFecalMicrobiota2015}.
 
-[The right anterior cingulate] has been linked to social cognition and reward-based
-decision making
-\cite{appsAnteriorCingulateGyrus2016,boesRightAnteriorCingulate2008,bushDorsalAnteriorCingulate2002}.
-Equol has a strong estrogenic effect
-\cite{setchellSEquolPotentLigand2005},
-and in the anterior cingulate, estrogen has been shown to regulate
-pain-related aversion
-\cite{xiaoEstrogenAnteriorCingulate2013}.
-
 \textit{R. gnavus} is increased in individuals with insulin
 resistance and obesity \cite{leyHumanGutMicrobes2006},
 conditions that are known to produce structural abnormalities in the brain
 \cite{opelBrainStructuralAbnormalities2021}.
+
 
 
 \subsection*{Main}
@@ -786,6 +767,61 @@ consequences than those at later ages. Further, even in the absence of
 causal impacts of microbial metabolism, identifying risk factors that
 could point to other early interventions would also have value.
 
+We identified several species in the family Eggerthelaceae that were
+associated with cognitive function, including \emph{Gordonibacter
+pamelaeae, Aldercreutzia equolofaciens, Asaccharobacter celatus}
+(formerly regarded a subspecies of \emph{A. equolofaciens}
+\cite{takahashiCompleteGenomeSequence2021}),
+and \emph{Eggerthella lenta}. Many members of this family are
+known in part due to unique metabolic activities. For example, \emph{A.
+equolofaciens} produces the nonsteroidal estrogen equol from isoflaven
+found in soybeans \cite{wangEnantioselectiveSynthesisSEquol2005}.
+This is particularly intriguing, since both \emph{A. equolofaciens} and \emph{A. celatus}
+were also the most important features in RF models of the
+right anterior cingulate, which has been linked to social cognition
+and reward-based decision making\cite{appsAnteriorCingulateGyrus2016,boesRightAnteriorCingulate2008,bushDorsalAnteriorCingulate2002},
+and estrogen has previously been shown to have activity 
+in this brain region\cite{xiaoEstrogenAnteriorCingulate2013}.
+\emph{G. pamelaeae} also has a unique metabolism that may impact the brain,
+as it can metabolize the polyphenol ellagic acid
+(found in pomegranates and some berries) into urolithin, which has been
+shown in some studies to have a neuroprotective effect
+\cite{gongUrolithinAlleviatesBloodbrain2022,selmaDescriptionUrolithinProduction2014}.
+While we could not find evidence of neurological roles for \emph{E. lenta},
+it has been extensively studied for
+its ability to metabolize drug compounds such as the plant-derived heart
+medication digoxin \cite{haiserPredictingManipulatingCardiac2013}.
+The metabolic versatility of this clade, and the large number of
+species that are associated with cognition make these microbes prime
+targets for further mechanistic studies.
+
+Other bacteria that were associated with both cognitive ability and
+brain structure had \hl{notable hints in the literature}. % This is stupid - find a better way to say this
+For example, RF models predicting the size of the left nucleus accumbens
+(but not the right) were dominated by \textit{Bacteroides} species,
+especially \textit{B. vulgatus}, \textit{B. uniformis}, and \textit{B. ovatus}.
+\textit{B. ovatus} has previously been shown to produce
+a number of neuroactive compounds including SCFAs and neurotransmitters
+such as GABA\cite{horvathBacteroidesOvatusColonization2022}.
+Another \textit{Bacteroides} species, \textit{B. fragilis} was
+able to ameliorate ASD-like symptoms in a mouse model
+by consuming a microbially-dependent metabolite 4-ethylphenylsulfate (4EPS)
+\cite{hsiaoMicrobiotaModulateBehavioral2013},
+while \textit{B. ovatus} is the primary producer of a precursor to 4EPS
+\cite{needhamGutderivedMetaboliteAlters2022} and increased anxiety
+behaviors
+
+Most healthy individuals have a
+rightward asymmetry in the nucleus accumbens,
+which is involved in reward learning and risk taking behaviours
+\cite{ernstAmygdalaNucleusAccumbens2005,yauNucleusAccumbensResponse2012}.
+Reduced asymmetry between right and left nucleus accumbens
+has been associated with substance use disorder in young adults
+\cite{caoMappingCorticalSubcortical2021}. The accumbens area is also
+associated with reward control, and in individuals diagnosed with ADHD,
+it has been shown to have a divergent neuromorphology
+\cite{hoogmanSubcorticalBrainVolume2017}.
+
 The use of shotgun metagenomic sequencing enabled us to get
 species-level resolution of microbial taxa. A previous study of
 cognition in 3 year old subjects used 16S rRNA gene amplicon sequencing,
@@ -796,33 +832,12 @@ higher scores on the Ages and Stages Questionnaire
 However, each of these clades encompass dozens of genera with
 diverse functions, each of which may have different effects. Indeed,
 several of the taxa that were positively associated with cognitive
-function in this study, including \emph{B. wexlerae}, the only species
-identified by linear models in children under 6 months, \emph{D.
+function in this study, including \emph{B. wexlerae}, \emph{D.
 longicatena}, \emph{R. faecis}, and \emph{A. finegoldii} are
 Clostridiales, as is \emph{R. gnavus}, which we found was negatively
 associated with cognitive function (Figure 2A-B). This kind of
 species-level resolution is typically not possible with amplicon
 sequencing.
-
-We identified several species in the family Eggerthelaceae that were
-associated with cognitive function, including \emph{Gordonibacter
-pamelaeae, Aldercreutzia equolofaciens, Asaccharobacter celatus}
-(formerly regarded a subspecies of \emph{A. equolofaciens}
-\cite{takahashiCompleteGenomeSequence2021}),
-and \emph{Eggerthella lenta}. Many members of this family are
-known in part due to unique metabolic activities. For example, \emph{A.
-equolofaciens} produces the nonsteroidal estrogen equol from isoflaven
-found in soybeans \cite{wangEnantioselectiveSynthesisSEquol2005},
-and \emph{G. pamelaeae} can metabolize the polyphenol ellagic acid
-(found in pomegranates and some berries) into urolithin, which has been
-shown in some studies to have a neuroprotective effect
-\cite{gongUrolithinAlleviatesBloodbrain2022,selmaDescriptionUrolithinProduction2014}.
-\emph{E. lenta} has been extensively studied for
-its ability to metabolize drug compounds such as the plant-derived heart
-medication digoxin \cite{haiserPredictingManipulatingCardiac2013}.
-The metabolic versatility of this clade, and the large number of
-species that are associated with cognition make these microbes prime
-targets for further mechanistic studies.
 
 In addition to improved species-level resolution, shotgun metagenomic
 sequencing also enables gene-functional insight. We showed here that
@@ -1067,7 +1082,7 @@ T1-weighted anatomical MRI data were acquired using a 3-Dimensional MP-RAGE sequ
 on 3T Siemens Trio scanner with the following parameters:
 TE=5.6msec, TR=1400msec, TI = 950msec, FA=15 degrees, and 1.1x1.1x1.1mm resolution.
 Image matrix and field-of-view were adjusted by infant size to achieve the desired image resolution.
-For children under ~4 years of age, MRI was performed during natural non-sedated sleep using previously described methods \hl{(Doug's paper ref)}.
+For children under ~4 years of age, MRI was performed during natural non-sedated sleep using previously described methods\cite{deanPediatricNeuroimagingUsing2014}.
 Older children were scanned awake whilst watching a movie or favorite TV show.
 To help minimize motion, pediatric (MedVac) immobilizers were used along with foam cushions and padding.
 Image quality was monitored during and following scanning.

--- a/manuscript/main.tex
+++ b/manuscript/main.tex
@@ -616,26 +616,12 @@ has one of the highest test-set correlations of our
 brain region models (R = 0.288), as compared to the right which
 had a negative mean test-set correlation (R = -0.041)
 indicated that generalizable models were not identified.
-Most healthy individuals have a
-rightward asymmetry in the nucleus accumbens,
-which is involved in reward learning and risk taking behaviours
-\cite{ernstAmygdalaNucleusAccumbens2005,yauNucleusAccumbensResponse2012}.
-Reduced asymmetry between right and left nucleus accumbens
-has been associated with substance use disorder in young adults
-\cite{caoMappingCorticalSubcortical2021}. The accumbens area is also
-associated with reward control, and in individuals diagnosed with ADHD,
-it has been shown to have a divergent neuromorphology
-\cite{hoogmanSubcorticalBrainVolume2017}.
 Feature importance for models of the left accumbens area were dominated
 by three species of \emph{Bacteroides}, \emph{B. vulgatus} (3.4\%
 relative importance), \emph{B. ovatus} (3.7\% relative importance), and
-\emph{B. uniformis} (3.0\% relative importance). Each of these species
-have been independently linked to ADHD
-\cite{wangGutMicrobiotaDietary2020}.
+\emph{B. uniformis} (3.0\% relative importance).
 
-
-Interestingly, while RF models for
-multiple brain regions had many important microbial taxa, others were
+While RF models for multiple brain regions had many important microbial taxa, others were
 dominated by a small number of taxa, many of which
 were also identified in LMs and RF models of cognitive function. 
 In general, for all segments, a
@@ -643,7 +629,7 @@ consistent number of species between 14 and 22 (median = 20) was
 responsible for one third of the fitness-weighted cumulative importance,
 regardless of model performance (\hl{Suplementary Table XX}, Figure 4 A and B).
 We observed two major patterns of importance distribution from
-taxa over the brain segments; some species portrayed high contributions
+species over the brain segments; some species portrayed high contributions
 to multiple different segments, while others contributed modestly to
 just one or two brain segments. Notable cases of the first pattern
 included seven species - \emph{Anaerostipes hadrus}, \emph{Bacteroides
@@ -671,60 +657,27 @@ on the taxa of interest (Figure 4C).
     \label{fig:4}
 \end{sidewaysfigure}
 
-Among these, the most important variable is \emph{Anaerostipes hadrus},
-which is a butyrate-producing anaerobe that has been positively
-associated with cognitive function
-\cite{kantGenomeSequenceButyrateProducing2015,liCorrelationsGutMicrobiota2022}.
-Its importance is, however, heavily loaded on the volume
-of entire major lobes (frontal, parietal), which cannot be readily
-correlated to specific cognitive functions, (Figure 4B).
+Among these, the most important variable is \emph{Anaerostipes hadrus}
+\hl{!!importance stats!!} (Figure 4B).
 \emph{B. wexlerae}, which was important in RF models of cognitive function,
 and was the only species to be significantly associated
-with cogntive function in young children, 
-was also important in models of the entorhinal, fusiform, lingual and
-parahippocampal regions. Previous works exploring Parkinson Disease patients
-found out that issues in the cognitive task of confrontation naming were
-positively correlated with thinning in the fusiform gyrus and
-parahippocampal gyrus
-\cite{pagonabarragaPatternRegionalCortical2013}.
-Additionally, the left and right parahippocampus, where \emph{B.
-wexlerae} had the highest importance in both models, are important in
-visual/spatial processing and memory
-\cite{aminoffRoleParahippocampalCortex2013}.
-\emph{B. wexlerae} can also produce acetylcholine in the gut
-\cite{hosomiOralAdministrationBlautia2022},
-and this molecule plays an important role in modulating memory function
-\cite{haamCholinergicModulationHippocampal2017}.
-Another cluster of model importance contains taxa associated with the
+with cogntive function in young children using LMs, 
+was also important in models of the entorhinal, fusiform and lingual areas
+and had the highest importance in models predicting the size of
+both the left and right right parahippocampus.
+Another cluster of model importance contained taxa associated with the
 basal forebrain, especially the cingulate and the accumbens. This
-cluster contains the previously-discussed \emph{B. ovatus} and \emph{B.
-uniformis}, but also \emph{Alistipes finegoldii and Streptococcus
-salivaris}. Reduction in the nucleus accumbens has been associated with
-depression symptoms \cite{wackerRoleNucleusAccumbens2009},
-and increased levels of the \emph{Alistipes} genus have been
-observed in patients with depressive disorder
-\cite{jiangAlteredFecalMicrobiota2015}.
+cluster contains \emph{B. ovatus} and \emph{B. uniformis},
+but also \emph{Alistipes finegoldii and Streptococcus salivaris}.
 
 Both \emph{A. equolofaciens} and \emph{A. celatus,} two closely-related
 equol-producing species, are examples of the second contribution
 pattern, where a model is dominated by a small number of taxa.
 Each of these species were highly important in predicting the relative volume of
 the right anterior cingulate (respectively, 3.0\% and 2.6\% relative
-importances), which has been linked to social cognition and reward-based
-decision making
-\cite{appsAnteriorCingulateGyrus2016,boesRightAnteriorCingulate2008,bushDorsalAnteriorCingulate2002}.
-Equol has a strong estrogenic effect
-\cite{setchellSEquolPotentLigand2005},
-and in the anterior cingulate, estrogen has been shown to regulate
-pain-related aversion
-\cite{xiaoEstrogenAnteriorCingulate2013}.
-Another example of this pattern is \emph{R. gnavus}, which was the only
+importances). Another example of this pattern is \emph{R. gnavus}, which was the only
 species with significant negative association with cognitive function in linear models.
-It is heavily associated with the left pars opercularis (2.7\% relative
-importance). \textit{R. gnavus} is increased in individuals with insulin
-resistance and obesity \cite{leyHumanGutMicrobes2006},
-conditions that are known to produce structural abnormalities in the brain
-\cite{opelBrainStructuralAbnormalities2021}.
+It is heavily associated with the left pars opercularis (2.7\% relative importance). 
 Finally, \emph{Coprococcus comes} displays an importance
 distribution that splits almost evenly among the two previously reported
 clusters. Its loading on the prediction of the left posterior cingulate

--- a/manuscript/main.tex
+++ b/manuscript/main.tex
@@ -372,7 +372,7 @@ residual variation due to age in both measures.
 \subsubsection*{Microbial species and neuroactive genes are associated with cognitive performance}
 
 To assess whether individual microbial species were associated with
-cognitive function, we fit multivariable linear regression models
+cognitive function, we fit multivariable linear regression models (LMs)
 \cite{mallickMultivariableAssociationDiscovery2021}
 for the relative abundance of each species that had at least 15\%
 prevalence in a given age group (Figure 2A, N\textsubscript{species} = 92 for 0--120 months, 
@@ -484,14 +484,12 @@ from the domain of genomics
 \cite{amaratungaEnrichedRandomForests2008,brieucPracticalIntroductionRandom2018,chenRandomForestsGenomic2012,franzosaGutMicrobiomeStructure2019,stephanRandomForestApproach2015},
 along with other works where it was used
 to predict cognitive conditions related to Alzheimer's disease in
-different scenarios
-\cite{ardekaniPredictionIncipientAlzheimer2017,velazquezRandomForestModel2021}.
+different scenarios \cite{ardekaniPredictionIncipientAlzheimer2017,velazquezRandomForestModel2021}.
 Additionally, given the sequential
 nature of variable consideration in each tree, RFs are naturally able to
 work out complex input feature interactions, such as those present in a
 microbiome-wide study, without the necessity to explicitly compute
-interaction terms.
-Given that gut microbial profiles, as well as neurocognitive
+interaction terms. Given that gut microbial profiles, as well as neurocognitive
 development, may partially reflect socioeconomic and demographic
 factors, we assessed the performance of RF regressors where maternal
 education (a proxy of socioeconomic status (SES)), sex, and age were
@@ -542,33 +540,30 @@ microbial taxonomic profiles (Table 3).
     \end{center}
 \end{table}
 
-As with linear models, RF models for children under 6 months old
+As with LMs, RF models for children under 6 months old
 performed poorly (mean test-set correlation -0.13, mean RMSE 12.70),
 but RFs were consistently able to learn the relationship between taxa
 and cognitive function scores in children over 18 months of age (mean
 test-set correlation 0.429, mean RMSE 17.29). For both age groups,
 species that were important in RF overlapped with those that were
-significant when testing the relationship with linear models (Figure
-3A-B, Supplementary Table \hl{XX}A-B), though there were substantial
-differences. For children under 6 months, only \emph{B. wexlerae} was
-significantly associated with cognitive function in linear models, but
-was ranked 20th in importance for RF models. The importance metric
-employed (MDI) is a measure of how well the variable differentiates
-(splits) sets of samples by creating subgroups that reduce the
-intra-group deviations, while also accounting for the amount of samples
-affected by a split. All taxa significantly associated with cognitive
-function score in children over 18 months using LMs belong to the
-top-ranking group responsible for 80\% of the total relative importance,
-except for \emph{Eubacterium ramulus} (Table 3, Figure 3A).
+significant when testing the relationship with LMs (Figure
+3A-B, Supplementary Table \hl{XX}A-B); aside from except for \emph{Eubacterium ramulus}
+all taxa that were significant using LMs belonged to a group
+responsible for 80\% of the total relative importance in RF models
+(Table 3, Figure 3A).
+However, the rank-ordering of LM significance and RF importance
+were had substantive differences. For example, in children under 6 months,
+only \emph{B. wexlerae} was significantly associated with cognitive function in LMs, but
+was ranked 20th in importance for RF models. 
 
-Interestingly, several taxa highly ranked in importance in both age
-groups, including several that were significant in LMs for children over
+Many taxa highly ranked in importance in RF models in both age
+groups, including several that were identified in LMs for children over
 18 months old, including \emph{R. gnavus} (0--6 months, rank = 13;
 18--120 months, rank = 7) and \emph{G. pamelaeae} (0--6 months, rank =
 16; 18--120 months, rank = 20), while others such as \emph{Allistipes
-finegoldii} were age-group specific. Several taxa important in RF models
-were not statistically significant when using linear models after
-multiple hypothesis correction. However, these taxa had small nominal
+finegoldii} were age-group specific. A number of taxa that were important in RF models
+were not statistically significant when using LMs after
+multiple hypothesis correction. However, these taxa often had small nominal
 p-values. For example, \emph{Erysipelatoclostridium ramosum} was the
 most important feature in RF models for children under 6 months old and
 had an LM p-value of 0.04. Subject age was consistently ranked highly in

--- a/manuscript/main.tex
+++ b/manuscript/main.tex
@@ -66,8 +66,8 @@ style=science
 
 \author{%
     \parbox{\linewidth}{\centering
-        Kevin S. Bongham,$^{1}$
-        Guilherme Fahur Botino,$^{1}$
+        Kevin S. Bonham,$^{1}$
+        Guilherme Fahur Bottino,$^{1}$
         Shelley Hoeft McCann,$^{1}$
         Jennifer Beauchemin,$^{2}$
         Elizabeth Weisse,$^{3}$

--- a/manuscript/main.tex
+++ b/manuscript/main.tex
@@ -383,7 +383,7 @@ age and maternal education (Figure 2B).
 By contrast, in children over 18 months of age,
 several mirobial species were significantly enriched (q-value
 \textless{} 0.20) in children with higher cognitive function scores,
-including \emph{Gordonibacter pamelaeae}
+including \emph{Gordonibacter pamelaeae},
 \emph{Asaccharobacter celatus} and \emph{Adelcreutzia equolifaciens}
 (also known as \textit{Adlercreutzia equolifaciens} subsp. \textit{celatus}
 and \textit{Adlercreutzia equolifaciens} subsp. \textit{equolifaciens} \cite{maruoAdlercreutziaEquolifaciensGen2008}),
@@ -437,31 +437,13 @@ scoring children over 18 months (E.S. -0.676, q = 0.023), as were genes
 for synthesizing the 2 carbon SCFA acetate in children under 6 months
 old (acetate synthesis I, E.S. = -0.194, q = 0.153; acetate synthesis
 II, E.S. = -0.342, q = 0.020; acetate synthesis III, E.S. = -0.31, q = 0.052).
-SCFAs are produced by anaerobic fermentation of dietary fiber
-and have been linked with immune system regulation as well as directly
-with brain function \cite{dalileRoleShortchainFatty2019}.
-
-We found that synthesis of menaquinone (vitamin K) was negatively associated with
-cognitive function score in older children (menaquinone synthesis I,
-E.S. = -0.170, q = 0.0183). Menaquinone has several isoforms, one of
-which, MK-4, has been found to be decreased in children diagnosed with ASD
-\cite{dongCorrelationSerumConcentrations2021}
-and is potentially neuroprotective in both rodents and humans
-\cite{elkattawyVitaminK2Menaquinone72022}.
-In children over 18 months old,
+In children over 18 months old, synthesis of menaquinone (vitamin K)
+was also negatively associated with cognitive function score (menaquinone synthesis I,
+E.S. = -0.170, q = 0.0183), while
 genes for the synthesis of the amino acids
 glutamate and tryptophan were significantly enriched in children with
-higher cognitive function scores (Glutamate synthesis I, E.S. = 0.242, q
-= 0.047; Tryptophan synthesis, E.S. = 0.119, q = 0.041). Glutamate is a
-critical neurotransmitter controlling neuronal excitatory/inhibitory
-signaling along with gamma-aminobutyric acid (GABA), and their balance
-in the brain controls neural plasticity and learning, particularly in
-the developing brain
-\cite{cohenkadoshLinkingGABAGlutamate2015,palomo-buitragoGlutamateInteractionsObesity2019}.
-Tryptophan metabolism, including
-microbial metabolism of tryptophan, has previously been linked with
-autism in children
-\cite{hoshinoBloodSerotoninFree1984,xiaoFecalMicrobiomeTransplantation2021}.
+higher cognitive function scores (Glutamate synthesis I, E.S. = 0.242, 
+q = 0.047; Tryptophan synthesis, E.S. = 0.119, q = 0.041).
 Taken together, these results suggest that
 microbial metabolic activity, particularly the metabolism (synthesis and
 degradation) of neuroactive compounds may have effects on cognitive

--- a/manuscript/main.tex
+++ b/manuscript/main.tex
@@ -255,19 +255,16 @@ These included shotgun metagenomic sequencing,
 age-appropriate cognitive and behavioral assessments
 using full-scale composite scores from the MSEL, WPPSI-4 and WISC-V,
 and neuroimaging measures of cortical and sub-cortical morphology. 
-To measure cognitive function, we used
-age-appropriate assessments that can be 
 Different assessment instruments were used depending on the child's age
 due to the unique age-range and psychometric properties measured by each
 (i.e., the MSEL for children under 4 years of age, The WPPSI-3 for 3-6 year-olds,
-and the WISC-V for children older than 6), but were normalized to a common scale (Figure 1B), 
-
+and the WISC-V for children older than 6), but were normalized to a common scale (Figure 1B),
 As expected, the greatest differences in microbial taxa were observed across
-child age (Figure 1B-C, PCoA axis 1), while older children were primarily
+child age (Figure 1C-D, PCoA axis 1), while older children were primarily
 stratified into Bacteroidetes-dominant, Firmicutes-dominant, or
 high-\emph{Prevotella copri} (Supplementary Figure 2). Overall variation
 in gut microbial genes and also in brain volume profiles was similarly
-driven largely by subject age (Figure 1C-F).
+driven largely by subject age (Figure 1E-F).
 
 \begin{sidewaysfigure}[!htb]
     \centering
@@ -334,13 +331,13 @@ we sought to determine if specific taxa or gene functions were linked with norma
 To test if variations in gut microbial taxa,
 their genes, or their metabolism are associated with neurocognitive
 development, we used permutation analysis of variance (PERMANOVA) 
-that included the @b diversity of microbial taxa and gene functions,
+that included the $\beta$ diversity of microbial taxa and gene functions,
 neuroimaging-derived volume measures of cortical and subcortical structures,
 and general cognitive ability.
 Given the large ecological shift in the microbiome that occurs upon the introduction of solid food,
 and the relatively wide range of ages when over which infant transition from milk to solid foods,
-we considered the pre-transition (prior to 6 months of age old)
-and post-transition (over 18 months of age) microbiomes separately.
+we considered ages that are generally pre-transition (prior to 6 months of age old)
+and those that are generally post-transition (over 18 months of age) separately.
 However, even with this categorization, we find increasing variation
 in gut microbiomes in children over 18 months old (Figure 1G).
 We also found that overall variation in microbial species in children over 18 months old
@@ -361,12 +358,12 @@ associated with variation in neuroimaging profiles (R\textsuperscript{2} = 0.256
 Consistent with prior studies, different microbial measurement types
 captured overlapping variation, with species profiles and gene function
 profiles, both generated from DNA sequencing data, being tightly coupled
-(Figure 1H, p \textless{} 0.001). Interestingly, other functional
+(Figure 1H, p \textless{} 0.001). Other functional
 groupings (Enzyme commission level4 - ECs
 \cite{bairochENZYMEDatabase20002000},
 and KEGG orthologues - KOs
-\cite{kanehisaKEGGResourceDeciphering2004}
-) overlapped only slightly with taxonomic profiles in both age
+\cite{kanehisaKEGGResourceDeciphering2004})
+overlapped only slightly with taxonomic profiles in both age
 cohorts, despite being derived from UniRef90 labels. In children over 18
 months, some variation (15.9\%, p \textless{} 0.01) in neuroimaging
 overlapped with microbial measures, though this may be due to the

--- a/manuscript/main.tex
+++ b/manuscript/main.tex
@@ -379,22 +379,14 @@ prevalence in a given age group (Figure 2A, N\textsubscript{species} = 92 for 0-
 N\textsubscript{species} = 46 for 0--6 months, N\textsubscript{species} = 97 for 18--120 months).
 Only \emph{Blautia wexlerae} was significantly associated (q value = 0.14, $\beta$ = 0.0015) with
 cognitive function in children under 6 months old after adjusting for
-age and maternal education (Figure 2B). \emph{B. wexlerae} was
-previously shown to be depleted in children with diabetes
-\cite{benitez-paezDepletionBlautiaSpecies2020},
-and that oral administration of \emph{B. wexlerae} partially
-ameliorated weight gain and inflammation from a high-fat diet in a mouse
-model of T2D
-\cite{hosomiOralAdministrationBlautia2022,liuBlautiaNewFunctional2021}.
-In children over 18 months of age,
-several microbial species were significantly enriched (q-value
+age and maternal education (Figure 2B).
+By contrast, in children over 18 months of age,
+several mirobial species were significantly enriched (q-value
 \textless{} 0.20) in children with higher cognitive function scores,
-including \emph{Gordonibacter pamelaeae}, which produces the
-neuroprotective metabolite urolithin
-\cite{gongUrolithinAlleviatesBloodbrain2022,selmaDescriptionUrolithinProduction2014},
-\emph{Asaccharobacter celatus} and
-\emph{Adelcreutzia equolifaciens}, which produce phytoestrogen-derived equol
-\cite{maruoAdlercreutziaEquolifaciensGen2008,thawornkunoBiotransformationDaidzeinEquol2009},
+including \emph{Gordonibacter pamelaeae}
+\emph{Asaccharobacter celatus} and \emph{Adelcreutzia equolifaciens}
+(also known as \textit{Adlercreutzia equolifaciens} subsp. \textit{celatus}
+and \textit{Adlercreutzia equolifaciens} subsp. \textit{equolifaciens} \cite{maruoAdlercreutziaEquolifaciensGen2008}),
 and SCFA-producing probiotic
 species such as \emph{Eubacterium eligens} and \emph{Faecalibacterium
 prausnitzii}

--- a/manuscript/main.tex
+++ b/manuscript/main.tex
@@ -130,8 +130,9 @@ volume of brain regions, with particular taxa, many that were identified
 as important in predicting cognitive function, dominating the
 feature importance metric for individual brain regions. For example, \emph{B.
 wexlerae} was dominant for the predicting the size of the parahippocampal region
-in both the left and right hemispheres, while several \textit{Bacteroitetes} species,
-including GABA-producing \emph{B. ovatus}, were important for predicting
+in both the left and right hemispheres, while several species from
+the phylum \textit{Bacteroidetes}, including GABA-producing
+\emph{B. ovatus}, were important for predicting
 the size of the left accumbens area, but not the right. These
 findings provide potential biomarkers of neurocognition and brain development
 and may lead to the future development of targets for early detection and early
@@ -163,8 +164,8 @@ development, are increasingly being identified
 \cite{spichakMiningMicrobesMental2021}.
 Both human epidemiology and animal models point to the effects
 of gut microbes on the development of autism spectrum disorder
-\cite{laueProspectiveAssociationsInfant2020,wanUnderdevelopmentGutMicrobiota2021}
-and particular microbial taxa have been associated with depression
+\cite{laueProspectiveAssociationsInfant2020,wanUnderdevelopmentGutMicrobiota2021},
+and specific microbial taxa have been associated with depression
 \cite{mayneris-perxachsMicrobiotaAlterationsProline2022,valles-colomerNeuroactivePotentialHuman2019}
 and Alzheimer's disease
 \cite{fungInteractionsMicrobiotaImmune2017,kimProbioticSupplementationImproves2021}.
@@ -175,9 +176,9 @@ particularly early in life.
 The first years of life are critical developmental windows for both the
 microbiome and the brain
 \cite{laueDevelopingMicrobiomeBirth2022}.
-Development \emph{in utero} is believed to be mostly sterile, but
-is rapidly seeded at birth through contact with the birth canal (if
-birthed vaginally), caregivers, food sources (breast milk or formula),
+Fetal development is believed to be mostly sterile, but newborns
+are rapidly seeded at birth through contact with the birth canal (if
+birthed vaginally), caregivers, food (breast milk or formula),
 and other environmental sources
 \cite{backhedDynamicsStabilizationHuman2015,bokulichAntibioticsBirthMode2016}.
 The early microbiome is characterized by low microbial
@@ -185,14 +186,14 @@ diversity, rapid succession and evolution, and domination by
 Actinobacteria, particularly the genus \emph{Bifidobacterium},
 Bacteroidetes, especially \emph{Bacteroides}, and Proteobacteria
 \cite{koenigSuccessionMicrobialConsortia2011}.
-Many of these microbes have specialized metabolic capabilities
-for digesting human breast milk, such as \emph{Bifidobacterium infantis}
-and \emph{Bacteroides fragilis}
+Many of these bacteria have specialized metabolic capabilities
+for digesting human breast milk, such as \emph{Bifidobacterium longum}
+subsp. \textit{infantis} and \emph{Bacteroides fragilis}
 \cite{selaGenomeSequenceBifidobacterium2008}.
 Upon the introduction of solid foods, the gut
-microbiome undergoes another categorical transformation, with most taxa
-of the infant microbiome being replaced by taxa more reminiscent of
-adult microbiomes
+microbiome undergoes another categorical transformation;
+its diversity increases, and most taxa of the infant microbiome
+are replaced by taxa more reminiscent of adult microbiomes
 \cite{backhedDynamicsStabilizationHuman2015}.
 Prior studies have typically focused on either infant microbiomes or
 adult microbiomes, since performing statistical analyses across this
@@ -211,14 +212,11 @@ connections has been established
 Much of this development occurs in discrete windows called
 sensitive periods (SPs)
 \cite{knudsenSensitivePeriodsDevelopment2004}
-during which neural plasticity is particularly high. The timing of these SPs
-is driven by both genetic and environmental cues, including the gut microbiome
-\cite{cowanAnnualResearchReview2020}.
+during which neural plasticity is particularly high.
 Emerging evidence suggests that the timing and duration of SPs
 may be driven in part by cues from the developing gut microbiome
-\cite{callaghanNestedSensitivePeriods2020}.
-As such,
-understanding the normal spectrum of healthy microbiome
+\cite{callaghanNestedSensitivePeriods2020,cowanAnnualResearchReview2020}.
+As such, understanding the normal spectrum of healthy microbiome
 development and how it relates to normal neurocognitive development may
 provide opportunities for identifying atypical development earlier and
 offer opportunities for intervention.

--- a/manuscript/main.tex
+++ b/manuscript/main.tex
@@ -494,9 +494,9 @@ microbiome-wide study, without the necessity to explicitly compute
 interaction terms. Given that gut microbial profiles, as well as neurocognitive
 development, may partially reflect socioeconomic and demographic
 factors, we assessed the performance of RF regressors where maternal
-education (a proxy of socioeconomic status (SES)), sex, and age were
-included as possible predictors, either alone or in combination with
-microbial taxonomic profiles (Table 3).
+education (here used as a proxy of socioeconomic status (SES)),
+sex, and age were included as possible predictors, either alone
+or in combination with microbial taxonomic profiles (Table 3).
 
 \begin{sidewaysfigure}[!htb]
     \centering

--- a/manuscript/main.tex
+++ b/manuscript/main.tex
@@ -693,62 +693,6 @@ importances, Left = 2.6\%, Right = 1.8\%).
 
 \section*{Discussion}
 
-\subsection*{Deleted}
-
-SCFAs are produced by anaerobic fermentation of dietary fiber
-and have been linked with immune system regulation as well as directly
-with brain function \cite{dalileRoleShortchainFatty2019}
-
-Menaquinone has several isoforms, one of
-which, MK-4, has been found to be decreased in children diagnosed with ASD
-\cite{dongCorrelationSerumConcentrations2021}
-and is potentially neuroprotective in both rodents and humans
-\cite{elkattawyVitaminK2Menaquinone72022}.
-
-Glutamate is a
-critical neurotransmitter controlling neuronal excitatory/inhibitory
-signaling along with gamma-aminobutyric acid (GABA), and their balance
-in the brain controls neural plasticity and learning, particularly in
-the developing brain
-\cite{cohenkadoshLinkingGABAGlutamate2015,palomo-buitragoGlutamateInteractionsObesity2019}.
-
-Tryptophan metabolism, including
-microbial metabolism of tryptophan, has previously been linked with
-autism in children
-\cite{hoshinoBloodSerotoninFree1984,xiaoFecalMicrobiomeTransplantation2021}.
-
-For children under 6 months, only \emph{B. wexlerae} was
-significantly associated with cognitive function in linear models, but
-was ranked 20th in importance for RF models.
-
-The importance metric
-employed (MDI) is a measure of how well the variable differentiates
-(splits) sets of samples by creating subgroups that reduce the
-intra-group deviations, while also accounting for the amount of samples
-affected by a split.
-
-[\emph{Anaerostipes hadrus}] is a butyrate-producing anaerobe that has been positively
-associated with cognitive function
-\cite{kantGenomeSequenceButyrateProducing2015,liCorrelationsGutMicrobiota2022}.
-Its importance is, however, heavily loaded on the volume
-of entire major lobes (frontal, parietal), which cannot be readily
-correlated to specific cognitive functions
-
-Reduction in the nucleus accumbens has been associated with
-depression symptoms \cite{wackerRoleNucleusAccumbens2009},
-and increased levels of the \emph{Alistipes} genus have been
-observed in patients with depressive disorder
-\cite{jiangAlteredFecalMicrobiota2015}.
-
-\textit{R. gnavus} is increased in individuals with insulin
-resistance and obesity \cite{leyHumanGutMicrobes2006},
-conditions that are known to produce structural abnormalities in the brain
-\cite{opelBrainStructuralAbnormalities2021}.
-
-
-
-\subsection*{Main}
-
 The relationship between the gut microbiome and brain function via the
 gut-microbiome-brain axis has gained increasing acceptance largely as a
 result of human epidemiological studies investigating atypical
@@ -760,7 +704,7 @@ The results from these studies point to the possibility
 that gut microbes and their metabolism may be causally implicated in
 cognitive development, but this study is the first to our knowledge that
 directly investigates microbial species and their genes in relation to
-typical development in young children. Understanding the gut-brain-axis
+typical development in young children. Understanding the gut-brain-microbiome axis
 in early life is particularly important, since differences or
 interventions in early life can have outsized and longer-term
 consequences than those at later ages. Further, even in the absence of
@@ -787,18 +731,18 @@ as it can metabolize the polyphenol ellagic acid
 (found in pomegranates and some berries) into urolithin, which has been
 shown in some studies to have a neuroprotective effect
 \cite{gongUrolithinAlleviatesBloodbrain2022,selmaDescriptionUrolithinProduction2014}.
-While we could not find evidence of neurological roles for \emph{E. lenta},
+While we could not find published evidence of neurological roles for \emph{E. lenta},
 it has been extensively studied for
 its ability to metabolize drug compounds such as the plant-derived heart
 medication digoxin \cite{haiserPredictingManipulatingCardiac2013}.
-The metabolic versatility of this clade, and the large number of
+The metabolic versatility of this clade and the large number of
 species that are associated with cognition make these microbes prime
 targets for further mechanistic studies.
 
 Other bacteria that were associated with both cognitive ability and
-brain structure had \hl{notable hints in the literature}. % This is stupid - find a better way to say this
+brain structure had also have intriguing connections in previous studies.
 For example, RF models predicting the size of the left nucleus accumbens
-(but not the right) were dominated by \textit{Bacteroides} species,
+were dominated by \textit{Bacteroides} species,
 especially \textit{B. vulgatus}, \textit{B. uniformis}, and \textit{B. ovatus}.
 \textit{B. ovatus} has previously been shown to produce
 a number of neuroactive compounds including SCFAs and neurotransmitters
@@ -807,11 +751,13 @@ Another \textit{Bacteroides} species, \textit{B. fragilis} was
 able to ameliorate ASD-like symptoms in a mouse model
 by consuming a microbially-dependent metabolite 4-ethylphenylsulfate (4EPS)
 \cite{hsiaoMicrobiotaModulateBehavioral2013},
-while \textit{B. ovatus} is the primary producer of a precursor to 4EPS
+while \textit{B. ovatus} is a primary producer of a precursor to 4EPS
 \cite{needhamGutderivedMetaboliteAlters2022} and increased anxiety
-behaviors
-
-Most healthy individuals have a
+behaviors in mice.
+The fact that the importance of these species in RF models,
+and the high performance of RF models in predicting this region
+were unilateral (affecting the left but not the right accumbens area)
+was also notable. Most healthy individuals have a
 rightward asymmetry in the nucleus accumbens,
 which is involved in reward learning and risk taking behaviours
 \cite{ernstAmygdalaNucleusAccumbens2005,yauNucleusAccumbensResponse2012}.
@@ -842,7 +788,18 @@ sequencing.
 In addition to improved species-level resolution, shotgun metagenomic
 sequencing also enables gene-functional insight. We showed here that
 genes for the metabolism of SCFAs, both their degradation and synthesis,
-are associated with cognitive function scores. However, while the
+are associated with cognitive function scores (Figure 2). 
+SCFAs are produced by anaerobic fermentation of dietary fiber
+and have been linked with immune system regulation as well as directly
+with brain function \cite{dalileRoleShortchainFatty2019}.
+Microbial metabolism of other potentially neuroactive molecules,
+were also associated with cognitive ability. We were particularly interested
+in genes for metabolizing glutamate, which is a
+critical neurotransmitter controlling neuronal excitatory/inhibitory
+signaling along with gamma-aminobutyric acid (GABA), and their balance
+in the brain controls neural plasticity and learning, particularly in
+the developing brain \cite{cohenkadoshLinkingGABAGlutamate2015,palomo-buitragoGlutamateInteractionsObesity2019}.
+However, while the
 differential abundance of genes for the metabolism of neuroactive
 compounds like these is suggestive, it is difficult to reason about the
 relationship between levels of these genes and the gut concentrations of
@@ -875,33 +832,24 @@ the study was occurring.
 \cite{blackwellYouthWellbeingCOVID192022,deoniImpactCOVID19Pandemic2021}
 (Supplementary Figure 3).
 
-
-% and alterations on the striatal
-% dopamine transporters can cause effects resembling hyperactivity and
-% attention deficit
-% \cite{yaelDisinhibitionNucleusAccumbens2019},
-% and that \emph{B. uniformis} is gut-microbial modulator of the brain
-% dopamine transporter
-% \cite{hartstraInfusionDonorFeces2020}.
-
-
 This analysis allowed us to establish links between microbial taxa and
 their functional potential with cognition and brain structure. Although
 we cannot test causality or the chemistry behind the interactions
-between gut microbial taxa, gut, and brain, this study provides clear
-and statistically significant associations between the infant and early
-child gut microbiota and neurocognition. Future studies should focus on
-characterizing the early-life microbiome and neurocognitive development
-across different geographic regions and lifestyles such as covering
-traditionally understudied low-resource urban, peri-urban and rural
-communities to obtain the more comprehensive understanding of the
+between gut microbial taxa and their genes, the gut, and the brain,
+this study provides clear and statistically significant associations
+between the infant and early child gut microbiota and neurocognition.
+Future studies should focus on characterizing the early-life microbiome
+and neurocognitive development across different geographic regions
+and lifestyles such as covering traditionally understudied populations,
+such as low-resource urban, peri-urban and rural communities
+to obtain the more comprehensive understanding of the
 variability within the different gut microbiomes reflects on
 neurocognition. These studies would also provide us with the wealth of
 data on different strains from the same species to better understand the
 effect of genes and their products. Furthermore, culturing and microbial
 community enrichment studies combined with genetic manipulation and
 genomic approaches to understand microbial metabolism at the molecular
-level is the key, as the metabolic functions shape and influence the
+level is key, as the metabolic functions shape and influence the
 human host and its health. The discovery of the neuroactive metabolites
 could provide us with biomarkers for early detection or necessary
 medicinally useful molecules that can be applied in intervention.

--- a/manuscript/main.tex
+++ b/manuscript/main.tex
@@ -577,7 +577,7 @@ or that age itself is a useful predictor.
 
 If there are causal effects of microbial metabolism on cognitive
 function, they might be reflected in changes in neuroanatomy. We again
-employed a Random Forest modeling approach to associate gut taxonomic
+employed a RF modeling approach to associate gut taxonomic
 profiles with individual brain regions identified in MRI scans.
 Some brain regions were more readily
 predicted by RF models trained on microbial taxa (Table 4, Supplementary
@@ -623,9 +623,9 @@ by three species of \emph{Bacteroides}, \emph{B. vulgatus} (3.4\%
 relative importance), \emph{B. ovatus} (3.7\% relative importance), and
 \emph{B. uniformis} (3.0\% relative importance).
 
-While RF models for multiple brain regions had many important microbial taxa, others were
-dominated by a small number of taxa, many of which
-were also identified in LMs and RF models of cognitive function. 
+While RF models for multiple brain regions had many important microbial taxa,
+others were dominated by a small number of taxa, many of which
+were also identified in LMs and RF models of cognitive function (Figures 2 and 3). 
 In general, for all segments, a
 consistent number of species between 14 and 22 (median = 20) was
 responsible for one third of the fitness-weighted cumulative importance,
@@ -660,7 +660,7 @@ on the taxa of interest (Figure 4C).
 \end{sidewaysfigure}
 
 Among these, the most important variable is \emph{Anaerostipes hadrus}
-\hl{!!importance stats!!} (Figure 4B).
+\hl{!!importance stats!!} (Figure 4B and C).
 \emph{B. wexlerae}, which was important in RF models of cognitive function,
 and was the only species to be significantly associated
 with cogntive function in young children using LMs, 
@@ -683,7 +683,7 @@ It is heavily associated with the left pars opercularis (2.7\% relative importan
 Finally, \emph{Coprococcus comes} displays an importance
 distribution that splits almost evenly among the two previously reported
 clusters. Its loading on the prediction of the left posterior cingulate
-is the highest for a microbe in RF models (4.0\% relative importance) -
+is the highest for a microbe in RF models (4.0\% relative importance);
 only age had higher relative importance in any model. At the same time,
 \textit{C. comes} is one of the most important predictors for neighboring areas of the
 posterior cingulate such as the pars opercularis (relative importances,
@@ -898,8 +898,20 @@ Shotgun metagenomic sequencing was performed on all samples. A pooled
 library (max 96 samples per run) was prepared using the Illumina Nextera
 Flex Kit for MiSeq and NextSeq from 1 ng of each sample. Samples were
 then pooled onto a plate and sequenced on the Illumina NextSeq 550
-platform using 150+150 bp paired-end ``high output'' chemistry,
+platform using 150+150 bp paired-end "high output";' chemistry,
 generating 400 million raw reads and 120 Gb of sequence per plate.
+
+\subsubsection*{Computational analysis of metagenomes}
+
+Shotgun metagenomic sequences were analyzed using the bioBakery suite of
+computational tools \cite{beghiniIntegratingTaxonomicFunctional2021}.
+First, KneadData (v0.7.7) was used to perform quality
+control of raw sequence reads, such as read trimming and removal of
+reads matching a human genome reference. Next, MetaPhlAn (v3.0.7, using
+database mpa\_v30\_CHOCOPhlAn\_201901) was used to generate taxonomic
+profiles by aligning reads to a reference database of marker genes.
+Finally, HUMAnN (v3.0.0a4) was used to functionally profile the
+metagenomes.
 
 \subsubsection*{Machine learning for cognitive development}
 
@@ -910,7 +922,7 @@ representations of the gut microbiome (taxonomic profiles, Functional
 profiles encoded as ECs) would behave, with and without the addition of
 demographics (sex and maternal education as a proxy of socioeconomic
 status) on participants from different age groups. Age (in months) was
-provided as a covariate for all models (Table 3).
+provided as a covariate for all models (Table 5).
 
 \textbf{Table 5. Experimental design and input composition for Random
 Forest experiments}
@@ -998,18 +1010,6 @@ and their volune calculated by summing the number of image voxels within each\ci
 
 Brain region volumes used in RF models were normalized to total brain volume
 (the sum of white and gray matter).
-
-\subsubsection*{Computational analysis of metagenomes}
-
-Shotgun metagenomic sequences were analyzed using the bioBakery suite of
-computational tools \cite{beghiniIntegratingTaxonomicFunctional2021}.
-First, KneadData (v0.7.7) was used to perform quality
-control of raw sequence reads, such as read trimming and removal of
-reads matching a human genome reference. Next, MetaPhlAn (v3.0.7, using
-database mpa\_v30\_CHOCOPhlAn\_201901) was used to generate taxonomic
-profiles by aligning reads to a reference database of marker genes.
-Finally, HUMAnN (v3.0.0a4) was used to functionally profile the
-metagenomes.
 
 \subsubsection*{Data and code availability}
 


### PR DESCRIPTION
As per Sean's review, I'm removing a bunch of stuff from the results into the discussion. But rather than doing it adhoc, I'm going to keep track of the removals here, and decide what to put back in.